### PR TITLE
chore: update `canary-release.yaml` to use git sha

### DIFF
--- a/.github/workflows/canary-release.yaml
+++ b/.github/workflows/canary-release.yaml
@@ -14,7 +14,7 @@ jobs:
       - run: yarn
       - run: yarn test
       - run: yarn build
-      - run: yarn version --no-git-tag-version --prerelease --preid=canary --access=public
+      - run: yarn version --no-git-tag-version --prerelease --preid=canary-$(git rev-parse --short HEAD) --access=public
       - uses: JS-DevTools/npm-publish@v1
         with:
           access: public


### PR DESCRIPTION
closes issue: https://github.com/michael-siek/coingecko-api/issues/17