### PR TITLE
chore: remove deleted CG endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,18 +162,6 @@ export default class CoinGeckoAPI {
 
   /**
    * @param id (required) Pass the coin id e.g. bitcoin.
-   * @param {PageBaseParams} params - Object to pass through
-   */
-
-  public async coinStatusUpdates(id: string, params?: PageBaseParams) {
-    assert(id, 'The ID of the coin is required e.g. Bitcoin.')
-
-    const method = 'coins/' + id + '/status_updates'
-    return await this.get(method, params)
-  }
-
-  /**
-   * @param id (required) Pass the coin id e.g. bitcoin.
    * @param {CoinOhlcParams} params - Object to pass through
    */
 
@@ -302,18 +290,6 @@ export default class CoinGeckoAPI {
 
   /**
    * @param id (required) ID of the exchange e.g. binance
-   * @param {PageBaseParams} - Object to pass through
-   */
-
-  public async exchangesStatusUpdates(id: string, params?: PageBaseParams) {
-    assert(id, 'Pass the exchange ID e.g. binance')
-
-    const method = 'exchanges/' + id + '/status_updates'
-    return await this.get(method, params)
-  }
-
-  /**
-   * @param id (required) ID of the exchange e.g. binance
    * @param days (required) Data up to number of days ago (eg. 1,14,30)
    */
 
@@ -325,15 +301,6 @@ export default class CoinGeckoAPI {
   }
 
   // Finance Endpoints
-
-  /**
-   * @param {PageBaseParams} params - Object to pass in
-   */
-
-  public async financePlatforms(params?: PageBaseParams) {
-    const method = 'finance_platforms'
-    return await this.get(method, params)
-  }
 
   /**
    * @param {FinanceProductParams} params - Object to pass in

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -178,17 +178,6 @@ describe('CoinGeckoAPI', () => {
     })
   })
 
-  describe('.coins/{id}/status_updates', () => {
-    it('Return status updates for a given coin', async () => {
-      const data = await coinGeckoApi.coinStatusUpdates('bitcoin')
-
-      assert.isObject(data)
-      assert.isNotNull(data.id)
-      assert.isNotNull(data.symbol)
-      assert.isNotNull(data.name)
-    })
-  })
-
   describe('.coins/{id}/ohlc', () => {
     it('Return candles body: 1-2 days: 30mins // 3-30 days: 4hours // 31 and before: 4 days', async () => {
       const data = await coinGeckoApi.coinOHLC('bitcoin', {
@@ -374,37 +363,12 @@ describe('CoinGeckoAPI', () => {
     })
   })
 
-  describe('./exchanges/{id}/status_updates', () => {
-    it('Return status updates for given exchange', async () => {
-      const data = await coinGeckoApi.exchangesStatusUpdates('binance')
-
-      assert.isObject(data)
-      assert.isNotNull(data.status_updates)
-      assert.isNotNull(data.status_updates.description)
-      assert.isNotNull(data.status_updates.category)
-      assert.isNotNull(data.status_updates.created_at)
-    })
-  })
-
   describe('./exchanges/{id}/volume_chart', () => {
     it('Return volume chart data for a given exchange', async () => {
       const data = await coinGeckoApi.exchangesVolumeChart('binance', 1)
 
       assert.isArray(data)
       assert.isNotNull(data)
-    })
-  })
-
-  describe('./finance_platforms', () => {
-    it('Return list of all finance platforms', async () => {
-      const data = await coinGeckoApi.financePlatforms()
-
-      assert.isArray(data)
-      assert.isNotNull(data.name)
-      assert.isNotNull(data.facts)
-      assert.isNotNull(data.category)
-      assert.isNotNull(data.centralized)
-      assert.isNotNull(data.website_url)
     })
   })
 


### PR DESCRIPTION
Turns out not to be a bug, the following endpoints were removed: 

```
.coins/{id}/status_updates 
./exchanges/{id}/status_updates
./finance_platforms
```

closes issue: https://github.com/michael-siek/coingecko-api/issues/30